### PR TITLE
feat: Configure FX3U PLC for Modbus TCP power control

### DIFF
--- a/tools/powersupply/modbus_control.st
+++ b/tools/powersupply/modbus_control.st
@@ -1,19 +1,18 @@
 (* PLC Program for Modbus TCP Controlled Output *)
 (*
   This program controls a physical output (Y0) based on the state
-  of a Modbus accessible coil (M8000).
+  of a Modbus accessible coil (M0).
 
-  - M8000: Internal auxiliary relay coil. This coil should be configured
-             to be accessible via Modbus TCP (e.g., as Modbus coil 00001
-             or another address depending on PLC/module mapping).
-             The external client (e.g., switch_power.py) will write to this coil.
+  - M0: Internal auxiliary relay coil. This coil will be configured
+        to be accessible via Modbus TCP as coil 0x0000 (the first coil).
+        The external client (e.g., switch_power.py) will write to this coil.
   - Y0: Physical output of the PLC that controls the power supply.
         (Ensure this output is appropriate for your application)
 *)
 
 // Main program loop (implicitly continuous scan in PLC)
 
-IF M8000 THEN // Check if the Modbus control coil M8000 is ON
+IF M0 THEN // Check if the Modbus control coil M0 is ON
   SET Y0;     // Turn ON the physical output Y0
 ELSE
   RST Y0;     // Turn OFF the physical output Y0

--- a/tools/powersupply/plc_config.st
+++ b/tools/powersupply/plc_config.st
@@ -1,0 +1,24 @@
+(* PLC Configuration Program *)
+(* This program should be run once after download, driven by M8411. *)
+(* A PLC power cycle is required AFTER this program has been run *)
+(* and parameters have been written to flash. *)
+
+IF M8411 THEN // M8411: Built-in flag for saving communication parameters
+
+  // Segment 1: Set PLC IP Address to 192.168.1.18
+  // D8470: IP Address Segment 1 (High Byte), Segment 2 (Low Byte)
+  // D8471: IP Address Segment 3 (High Byte), Segment 4 (Low Byte)
+  D8470 := H_C0A8; // 192.168
+  D8471 := H_0112; // 1.18
+
+  // Segment 2: Configure Modbus TCP Coil Mapping
+  // Map M0 as the first Modbus coil (address 0x0000)
+  // This maps a block of 32 M-coils starting from M0.
+  // D8476: Bit 15-13 (Number of Points), Bit 12-0 (Starting Address Type/Offset)
+  // Upper 3 bits '001' = 1 * 32 points.
+  // Lower 13 bits '0000100000000' (0x0080) = M element, starting at M0.
+  D8476 := H_2080; // Map M0...M31 to Modbus Coils 0x0000 - 0x001F
+
+END_IF;
+
+(* End of Configuration Program *)


### PR DESCRIPTION
This commit introduces ST code and modifications to enable power supply control via Modbus TCP for an AMX-FX3U-26MT-E PLC (or compatible clone).

New ST code `tools/powersupply/plc_config.st` is added to:
1.  Set the PLC's IP address to 192.168.1.18 (via D8470, D8471).
2.  Configure Modbus TCP coil mapping by setting D8476 to map PLC internal coil M0 to Modbus coil address 0x0000. This configuration requires M8411 to be active during a PLC scan and a subsequent power cycle of the PLC to take effect.

The existing ST code `tools/powersupply/modbus_control.st` has been modified to use the general-purpose auxiliary relay M0 (instead of the special relay M8000) to control the physical output Y0. This makes the control mechanism compatible with the Modbus mapping configured via D8476.

You have been provided with instructions for uploading this code to the PLC, ensuring the configuration code runs, power cycling the PLC, and updating your external Python script to target Modbus coil 0 at IP 192.168.1.18.