### PR TITLE
Fix: Correct TypeError in calc_checksum_byte for Python 2

### DIFF
--- a/client.py
+++ b/client.py
@@ -85,9 +85,9 @@ def print_answ(r, answ):
 def calc_checksum_byte(incoming): # Type hint for clarity
     # Format: <len_byte><byte_00>..<byte_xx><checksum_byte>
     # Checksum: LSB of negative sum of byte values
-    length_val = incoming[0]
-    # Sum bytes from index 1 up to 1+length_val (exclusive of checksum itself)
-    current_sum = sum(incoming[0:1+length_val]) # Sum includes the length byte itself up to last content byte
+    # 'incoming' is full_msg_before_checksum = bytes([len(msg) + 1]) + msg
+    # This means 'incoming' is exactly the bytes (Length + Payload) over which the sum should occur.
+    current_sum = sum(ord(c) for c in incoming)
     # LSB of negative sum
     checksum_val = (-current_sum) & 0xFF
     return bytes([checksum_val])


### PR DESCRIPTION
- Modified `calc_checksum_byte` in `client.py` to correctly sum the ordinal values of all incoming bytes using `sum(ord(c) for c in incoming)`.
- This resolves a `TypeError: unsupported operand type(s) for +: 'int' and 'str'` that occurred due to incorrect string manipulation and summation in Python 2.

This change is critical for basic packet sending functionality and builds _upon previous fixes for handshake logic, payload bugs, UART delays, and other Python 2 compatibility adjustments.