### PR TITLE
Fix: Use hexlify for str hex representation in Python 2

### DIFF
--- a/client.py
+++ b/client.py
@@ -115,7 +115,7 @@ def send_packet(r, msg, step=2, sleep_amt=0.01): # Type hint for clarity
     checksum = calc_checksum_byte(full_msg_before_checksum)
     full_msg_with_checksum = full_msg_before_checksum + checksum
 
-    log.info("sending packet: {}".format(full_msg_with_checksum.hex()))
+    log.info("sending packet: {}".format(hexlify(full_msg_with_checksum)))
     for i in range(0, len(full_msg_with_checksum), step):
         time.sleep(sleep_amt)
         r.send(full_msg_with_checksum[i:i+step])


### PR DESCRIPTION
- Replaced `full_msg_with_checksum.hex()` with `hexlify(full_msg_with_checksum)` in the `send_packet` function within `client.py`.
- The `.hex()` method for strings is not available in Python 2.7, causing an `AttributeError`. `binascii.hexlify()` provides the correct equivalent functionality for Python 2.

This addresses a Python 2 compatibility issue that prevented packet sending and logging. This fix builds upon previous efforts to correct payload logic, handshake timing, UART delays, and other Python 2 issues.